### PR TITLE
composeApp: add Android nav

### DIFF
--- a/ZwiftViewer/composeApp/build.gradle.kts
+++ b/ZwiftViewer/composeApp/build.gradle.kts
@@ -77,7 +77,8 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.navigation.runtime.android)
+    implementation(libs.androidx.navigation.compose)
     debugImplementation(compose.uiTooling)
     lintChecks(libs.lint.checks)
 }
-

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/MainActivity.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/MainActivity.kt
@@ -1,117 +1,48 @@
 package com.danielchew.zwiftviewer
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.compose.material3.Text
-import androidx.compose.runtime.*
-import com.danielchew.zwiftviewer.network.KtorClientProvider.provideAuthenticatedClient
-import com.danielchew.zwiftviewer.network.RideUiState
-import com.danielchew.zwiftviewer.network.ZwiftPowerProfileApi
-import com.danielchew.zwiftviewer.ui.RideCard
-import com.danielchew.zwiftviewer.viewmodel.RideViewModel
-import com.danielchew.zwiftviewer.util.extractCookiesForDomain
-import com.danielchew.zwiftviewer.utils.extractZwiftPowerUserId
-
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.danielchew.zwiftviewer.ui.login.LoginScreen
+import com.danielchew.zwiftviewer.ui.ridelist.RideListScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        Log.d("ZwiftDebug", "App launched")
         super.onCreate(savedInstanceState)
-
         setContent {
-            Log.d("ZwiftDebug", "Log is working")
-            val cookiesState = remember { mutableStateOf<Map<String, String>?>(null) }
-            val isLoggedInState = remember { mutableStateOf<Boolean?>(null) }
+            ZwiftViewerApp()
+        }
+    }
+}
 
-            // Move extraction inside composition
-            LaunchedEffect(Unit) {
-                val parsedCookies = extractCookiesForDomain("https://zwiftpower.com")
-                cookiesState.value = parsedCookies
-                Log.d("ZwiftDebug", "Extracted cookies: ${parsedCookies?.keys}")
-                Log.d("ZwiftDebug", "All cookies: ${cookiesState.value?.entries}")
-            }
+@Composable
+fun ZwiftViewerApp() {
+    val navController = rememberNavController()
 
-            when (val parsedCookies = cookiesState.value) {
-                null -> {
-                    // Still loading cookies — show a loading state or nothing
-                    Text("Loading...")
-                }
+    Surface(color = MaterialTheme.colorScheme.background) {
+        AppNavigation(navController = navController)
+    }
+}
 
-                else -> {
-                    if (parsedCookies.isEmpty()) {
-                        ZwiftPowerLoginScreen { extractedCookies: Map<String, String> ->
-                            cookiesState.value = extractedCookies
-                        }
-                        return@setContent
-                    } else {
-                        // Prepare client, api, and viewModel before LaunchedEffect
-                        val client = provideAuthenticatedClient(parsedCookies)
-                        val api = ZwiftPowerProfileApi(client)
-                        val viewModel = remember(parsedCookies) { RideViewModel(api) }
-
-                        // Check login state in LaunchedEffect, set isLoggedInState, and load rides if possible
-                        LaunchedEffect(parsedCookies) {
-                            val profileId = extractZwiftPowerUserId(client)
-                            val isLoggedIn = profileId != null
-                            if (profileId == null) {
-                                Log.e("ZwiftDebug", "Failed to extract ZwiftPower user ID. Login likely failed.")
-                            } else {
-                                Log.d("ZwiftDebug", "Parsed ZwiftPower user ID: $profileId")
-                            }
-
-                            if (isLoggedIn && profileId != null) {
-                                viewModel.loadRides(profileId, parsedCookies)
-                            } else {
-                                Log.d("ZwiftDebug", "Login failed or profileId is null.")
-                            }
-
-                            isLoggedInState.value = isLoggedIn
-                        }
-
-                        when (isLoggedInState.value) {
-                            null -> {
-                                Text("Checking login...")
-                            }
-                            false -> {
-                                ZwiftPowerLoginScreen { newCookies ->
-                                    cookiesState.value = newCookies
-                                    isLoggedInState.value = null // retry login check after new cookies
-                                }
-                            }
-                            else -> {
-                                val rideState by viewModel.state.collectAsState()
-                                when (rideState) {
-                                    is RideUiState.Loading -> Text("Loading rides...")
-                                    is RideUiState.Error -> Text("Error: ${(rideState as RideUiState.Error).message}")
-                                    is RideUiState.Success -> {
-                                        val rides = (rideState as RideUiState.Success).rides
-                                        LazyColumn(
-                                            modifier = Modifier
-                                                .fillMaxSize()
-                                                .padding(16.dp)
-                                        ) {
-                                            items(rides) { ride ->
-                                                RideCard(ride)
-                                                Spacer(modifier = Modifier.height(8.dp))
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+@Composable
+fun AppNavigation(navController: NavHostController) {
+    NavHost(navController = navController, startDestination = "login") {
+        composable("login") {
+            LoginScreen(navController)
+        }
+        composable("rides") {
+            RideListScreen(navController)
+        }
+        composable("rideDetail/{rideId}") { backStackEntry ->
+            val rideId = backStackEntry.arguments?.getString("rideId") ?: ""
+            com.danielchew.zwiftviewer.ui.ridedetail.RideDetailScreen(rideId)
         }
     }
 }

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/components/RideCard.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/components/RideCard.kt
@@ -1,4 +1,4 @@
-package com.danielchew.zwiftviewer.ui
+package com.danielchew.zwiftviewer.ui.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/login/LoginScreen.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/login/LoginScreen.kt
@@ -1,0 +1,57 @@
+package com.danielchew.zwiftviewer.ui.login
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.danielchew.zwiftviewer.ui.login.LoginViewModel
+
+@Composable
+fun LoginScreen(navController: NavController) {
+    val viewModel: LoginViewModel = viewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(text = "Login to Zwift", style = MaterialTheme.typography.headlineSmall)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(text = "Username")
+        TextField(
+            value = uiState.username,
+            onValueChange = { viewModel.onUsernameChanged(it) },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(text = "Password")
+        TextField(
+            value = uiState.password,
+            onValueChange = { viewModel.onPasswordChanged(it) },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(onClick = {
+            if (viewModel.onLoginClicked()) {
+                navController.navigate("rides")
+            }
+        }) {
+            Text("Login")
+        }
+    }
+}

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/login/LoginUiState.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/login/LoginUiState.kt
@@ -1,0 +1,6 @@
+package com.danielchew.zwiftviewer.ui.login
+
+data class LoginUiState(
+    val username: String = "",
+    val password: String = ""
+)

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/login/LoginViewModel.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/login/LoginViewModel.kt
@@ -1,0 +1,25 @@
+package com.danielchew.zwiftviewer.ui.login
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+class LoginViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LoginUiState())
+    val uiState: StateFlow<LoginUiState> = _uiState
+
+    fun onUsernameChanged(new: String) {
+        _uiState.update { it.copy(username = new) }
+    }
+
+    fun onPasswordChanged(new: String) {
+        _uiState.update { it.copy(password = new) }
+    }
+
+    fun onLoginClicked(): Boolean {
+        // For now, just return true always
+        return true
+    }
+}

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridedetail/RideDetailScreen.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridedetail/RideDetailScreen.kt
@@ -1,0 +1,28 @@
+package com.danielchew.zwiftviewer.ui.ridedetail
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.danielchew.zwiftviewer.ui.components.RideCard
+
+@Composable
+fun RideDetailScreen(rideId: String) {
+    val viewModel: RideDetailViewModel = viewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(rideId) {
+        viewModel.loadRideById(rideId)
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Ride Detail", style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        uiState.ride?.let {
+            RideCard(ride = it)
+        } ?: Text("Loading ride...")
+    }
+}

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridedetail/RideDetailUiState.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridedetail/RideDetailUiState.kt
@@ -1,0 +1,9 @@
+package com.danielchew.zwiftviewer.ui.ridedetail
+
+import com.danielchew.zwiftviewer.ZwiftPowerRide
+
+data class RideDetailUiState(
+    val ride: ZwiftPowerRide? = null,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null
+)

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridedetail/RideDetailViewModel.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridedetail/RideDetailViewModel.kt
@@ -1,0 +1,37 @@
+package com.danielchew.zwiftviewer.ui.ridedetail
+
+import androidx.lifecycle.ViewModel
+import com.danielchew.zwiftviewer.ZwiftPowerRide
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class RideDetailViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RideDetailUiState())
+    val uiState: StateFlow<RideDetailUiState> = _uiState
+
+    fun loadRideById(rideId: String) {
+        // For now, return a hardcoded ride
+        val mockRide = ZwiftPowerRide(
+            date = 1720000000000, // any mock timestamp
+            zaid = "zaid123",
+            title = "Mock Ride $rideId",
+            zid = "zid456",
+            elapsed = listOf(3600),
+            distance = 25000,
+            worldId = "1",
+            sport = "cycling",
+            fit = "fit789",
+            aid = "aid999",
+            avgSpeed = 38,
+            avgHr = listOf(140),
+            maxHr = listOf(180),
+            avgCadence = listOf(85),
+            calories = 600,
+            avgPower = listOf(185),
+            elevation = 300,
+            zeid = 1234
+        )
+        _uiState.value = RideDetailUiState(ride = mockRide)
+    }
+}

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridelist/RideListScreen.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridelist/RideListScreen.kt
@@ -1,0 +1,38 @@
+package com.danielchew.zwiftviewer.ui.ridelist
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+
+@Composable
+fun RideListScreen(navController: NavController) {
+    val viewModel: RideListViewModel = viewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Ride List", style = MaterialTheme.typography.headlineMedium)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        uiState.rides.forEach { ride ->
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+                    .clickable {
+                        navController.navigate("rideDetail/${ride.id}")
+                    }
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(text = ride.name, style = MaterialTheme.typography.titleMedium)
+                    Text(text = ride.date, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridelist/RideListUiState.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridelist/RideListUiState.kt
@@ -1,0 +1,11 @@
+package com.danielchew.zwiftviewer.ui.ridelist
+
+data class Ride(
+    val id: String,
+    val name: String,
+    val date: String
+)
+
+data class RideListUiState(
+    val rides: List<Ride> = emptyList()
+)

--- a/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridelist/RideListViewModel.kt
+++ b/ZwiftViewer/composeApp/src/androidMain/kotlin/com/danielchew/zwiftviewer/ui/ridelist/RideListViewModel.kt
@@ -1,0 +1,18 @@
+package com.danielchew.zwiftviewer.ui.ridelist
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class RideListViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        RideListUiState(
+            rides = listOf(
+                Ride("1", "Zwift Race - Volcano Circuit", "2025-06-01"),
+                Ride("2", "Group Workout - FTP Builder", "2025-06-10")
+            )
+        )
+    )
+    val uiState: StateFlow<RideListUiState> = _uiState
+}

--- a/ZwiftViewer/gradle/libs.versions.toml
+++ b/ZwiftViewer/gradle/libs.versions.toml
@@ -15,8 +15,11 @@ junit = "4.13.2"
 kotlin = "2.1.21"
 lint = "31.2.1"
 lintChecks = "31.10.1"
+navigationRuntimeAndroid = "2.9.0"
+navigationComposeJvmstubs = "2.9.0"
 
 [libraries]
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationRuntimeAndroid" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit" }
@@ -29,6 +32,8 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "lintChecks" }
+androidx-navigation-runtime-android = { group = "androidx.navigation", name = "navigation-runtime-android", version.ref = "navigationRuntimeAndroid" }
+androidx-navigation-compose-jvmstubs = { group = "androidx.navigation", name = "navigation-compose-jvmstubs", version.ref = "navigationComposeJvmstubs" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Adds navigation between login, ride list, and ride detail screens using hardcoded data. ViewModels and UI state are structured per screen. Back nav works. 

AI:
- Ready for iOS mirroring and real data wiring.