### PR TITLE
PR: iOS Logout & Nav-loop fix

### DIFF
--- a/ZwiftViewer/iosApp/ZwiftVieweriOS/ZwiftVieweriOS.xcodeproj/project.pbxproj
+++ b/ZwiftViewer/iosApp/ZwiftVieweriOS/ZwiftVieweriOS.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1BC5F0552E300D180036AC75 /* Shared.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B6353462E00AFF500C76C3B /* Shared.xcframework */; };
-		1BC5F0562E300D180036AC75 /* Shared.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B6353462E00AFF500C76C3B /* Shared.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1BF3FEBA2E303CD600F19569 /* Shared.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B6353462E00AFF500C76C3B /* Shared.xcframework */; };
+		1BF3FEBB2E303CD600F19569 /* Shared.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B6353462E00AFF500C76C3B /* Shared.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -29,13 +29,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		1BC5F0572E300D180036AC75 /* Embed Frameworks */ = {
+		1BF3FEBC2E303CD600F19569 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				1BC5F0562E300D180036AC75 /* Shared.xcframework in Embed Frameworks */,
+				1BF3FEBB2E303CD600F19569 /* Shared.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -73,7 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1BC5F0552E300D180036AC75 /* Shared.xcframework in Frameworks */,
+				1BF3FEBA2E303CD600F19569 /* Shared.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -134,7 +134,7 @@
 				1BC89CB62DFE1B6200E0ADB1 /* Sources */,
 				1BC89CB72DFE1B6200E0ADB1 /* Frameworks */,
 				1BC89CB82DFE1B6200E0ADB1 /* Resources */,
-				1BC5F0572E300D180036AC75 /* Embed Frameworks */,
+				1BF3FEBC2E303CD600F19569 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/ZwiftViewer/iosApp/ZwiftVieweriOS/ZwiftVieweriOS/Views/RideList/RideListView.swift
+++ b/ZwiftViewer/iosApp/ZwiftVieweriOS/ZwiftVieweriOS/Views/RideList/RideListView.swift
@@ -1,3 +1,21 @@
+//
+//  RideListView.swift
+//  ZwiftVieweriOS
+//
+//  Created by Daniel Chew on 6/17/25.
+//
+
+import SwiftUI
+import os
+import WebKit
+import Shared
+
+private let logger = Logger(subsystem: "com.danielchew.zwiftviewer", category: "ZwiftDebug")
+
+private func cookieHeader(from cookies: [HTTPCookie]) -> String {
+    cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+}
+
 func formatRideDate(_ ride: Ride) -> String {
     guard let dateWrapper = ride.date,
           let epochSeconds = dateWrapper.toEpochSecondsOrNull() else {
@@ -34,18 +52,6 @@ func rideStatsText(for ride: Ride) -> (String, String, String) {
 
     return (distanceText, elevationText, elapsedText)
 }
-//
-//  RideListView.swift
-//  ZwiftVieweriOS
-//
-//  Created by Daniel Chew on 6/17/25.
-//
-
-import SwiftUI
-import Shared
-import os
-
-private let logger = Logger(subsystem: "com.danielchew.zwiftviewer", category: "ZwiftDebug")
 
 struct RideListView: View {
     let cookies: [HTTPCookie]
@@ -109,6 +115,16 @@ struct RideListView: View {
         }
         .listStyle(PlainListStyle())
         .padding()
+        .toolbar {
+            Button("Logout") {
+                Task {
+                    let header = cookieHeader(from: cookies)
+                    try? await Logout_iosKt.logout(cookieHeader: header)
+                    Logout_iosKt.clearAllZwiftCookies()
+                    onBack?()
+                }
+            }
+        }
         .onAppear {
             logger.info("RideListView: onAppear triggered")
             Task {


### PR DESCRIPTION
	•	Adds Logout button to RideListView
	•	Calls shared Logout_iosKt.logout(cookieHeader:)
	•	Clears ZwiftPower + SSO cookies via Logout_iosKt.clearAllZwiftCookies()
	•	Mirrors Android nav behaviour
	•	Success callback fires once, then pops Login from stack → no bounce-back loop
	•	No new dependencies; re-exports already in shared XCFramework

Verified on Simulator:
	1.	Login → rides list loads
	2.	Tap Logout → login screen
	3.	Re-login → single tap loads rides, stays on list, back exits app.